### PR TITLE
Fix: 最後の歌詞が表示されずコンソールエラーになるのを修正した。

### DIFF
--- a/app/frontend/components/PracticeBody.vue
+++ b/app/frontend/components/PracticeBody.vue
@@ -397,6 +397,11 @@
             },
             showLyric(line){
                 const nextLineIndex = this.lyricsLines.indexOf(line) + 1
+                // もし次のライン（歌詞）がない場合（つまりnextLineIndexと配列の要素数と同じ）：
+                if (nextLineIndex === this.lyricsLines.length &&
+                    this.currentTime + this.timeOffset >= line.time) {
+                    return true
+                }
                 const nextLine = this.lyricsLines[nextLineIndex]
                 if (this.currentTime + this.timeOffset >= line.time && 
                     this.currentTime + this.timeOffset <= nextLine.time) {


### PR DESCRIPTION
## 変更の概要

* 歌詞を表示させる挿せないのメソッドの判定ロジックを修正しました。
* 関連するIssueやプルリクエスト #19 

## やったこと

* [x] showLyric メソッドにもう一つのif 条件分岐を設け、「次の歌詞がない場合」の判定ロジックを組みました。

## 動作確認

* 再現手順：
1. 動画を再生します。
2. 最後の歌詞がくる手前にジャンプし、コンソールエラーがないことを確認します。
3. 最後の歌詞が表示されるべきタイミングに正しく表示されることを確認します。
