### PR TITLE
fix: YouTube動画を読み込むときの「DOMWindow」エラーを解消した

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -10,6 +10,7 @@ html
         = csp_meta_tag
         / = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
         = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
+        = javascript_include_tag "https://www.youtube.com/iframe_api" 
         = stylesheet_link_tag "https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;700&family=Russo+One&display=swap"
         = stylesheet_link_tag "https://cdn.jsdelivr.net/npm/@mdi/font@6.x/css/materialdesignicons.min.css"
         = favicon_pack_tag "favicon.png"


### PR DESCRIPTION
## 変更の概要

* 関連するIssueやプルリクエスト #20 

## なぜこの変更をするのか

* いろいろなサイトを参考してこのように変更しました。
ダメでした：[vue-youtubeの公式issue](https://github.com/anteriovieira/vue-youtube/issues/13)
ダメでした：[stackoverflow](https://stackoverflow.com/questions/27573017/failed-to-execute-postmessage-on-domwindow-https-www-youtube-com-http)
いけました：[teratail](https://teratail.com/questions/119741)

## 変更箇所

* app/views/layouts/application.html.slim
headタグに `https://www.youtube.com/iframe_api` を読み込みました。

## 動作確認

* 練習画面にてリロードを試し、動画が正常に再生できること、コンソールエラーが出ないことを確認できます。
