### PR TITLE
fix: サーバのmysqlとのsocket不一致を修正した。

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -29,6 +29,7 @@ test:
   database: Sycall_test
   username: <%= ENV['DATABASE_USERNAME'] %>
   password: <%= ENV['DATABASE_PASSWORD'] %>
+  socket: /var/lib/mysql/mysql.sock
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is


### PR DESCRIPTION
## 変更の概要

* database.yml のproductionの記述を変更しました

## なぜこの変更をするのか

* サーバー上のmysqlのソケットとdatabase.ymlの記述が記述が合っていないため。

