### PR TITLE
fix: 前ブランチの修正に誤りがあったため、再度修正した

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -29,7 +29,6 @@ test:
   database: Sycall_test
   username: <%= ENV['DATABASE_USERNAME'] %>
   password: <%= ENV['DATABASE_PASSWORD'] %>
-  socket: /var/lib/mysql/mysql.sock
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -56,3 +55,4 @@ production:
   username: <%= ENV['DATABASE_USERNAME'] %>
   password: <%= ENV['DATABASE_PASSWORD'] %>
   host: <%= ENV['DATABASE_HOST'] %>
+  socket: /var/lib/mysql/mysql.sock


### PR DESCRIPTION
## 変更の概要

* 前ブランチの修正に誤りがあったため、再度修正した

## なぜこの変更をするのか

* 追加すべきコードをtest環境のところに記述してしまったため、productionのところに修正しました。
