### PR TITLE
fix: CSSが表示されない問題の修正を試みた。

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -8,7 +8,6 @@ html
         meta name="viewport" content="width=device-width, initial-scale=1.0"/
         = csrf_meta_tags
         = csp_meta_tag
-        / = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
         = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
         = javascript_include_tag "https://www.youtube.com/iframe_api" 
         = stylesheet_link_tag "https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;700&family=Russo+One&display=swap"

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -92,7 +92,7 @@ production:
   compile: false
 
   # Extract and emit a css file
-  extract_css: true
+  extract_css: false
 
   # Cache manifest.json for performance
   cache_manifest: true


### PR DESCRIPTION
## 変更の概要

* デプロイ後VuetifyのCSSが表示されない問題を修正してみます。

## なぜこの変更をするのか

* VuetifyのCSSが表示されなかったため。

## 変更内容

* `extract_css: true`　→     `extract_css: false`