### PR TITLE
Add: 準備画面から練習画面へのルーティング処理を完成させた

### DIFF
--- a/app/controllers/calls_controller.rb
+++ b/app/controllers/calls_controller.rb
@@ -2,4 +2,5 @@ class CallsController < ApplicationController
     def search
         @calls = LyricsVersion.search_calls_info(params[:keyword])
     end
+    #TODO コールid → get_lyrics アクション → 歌詞を加工し、Jsonをクライアントに返す
 end

--- a/app/frontend/App.vue
+++ b/app/frontend/App.vue
@@ -3,7 +3,9 @@
         <NavBar></NavBar>
         <v-main >
             <transition appear enter-active-class="animate__animated animate__fadeIn">
-                <router-view></router-view>
+                <keep-alive include="PreparationBody">
+                    <router-view></router-view>
+                </keep-alive>
             </transition>
         </v-main>
         <Footer ></Footer>

--- a/app/frontend/components/PracticeBody.vue
+++ b/app/frontend/components/PracticeBody.vue
@@ -13,6 +13,7 @@
 </template>
 
 <script>
+    import axios from 'axios'
     import Video from './Video.vue'
     import Subtitle from './Subtitle.vue'
 
@@ -27,7 +28,6 @@
                 song: "Make you happy",
                 artist: "NiziU",
                 bpm: 160,
-                // TODO Rails より受け取った歌詞Jsonを格納する
                 lyricsLines: [
                     {
                         "time": 1.694,
@@ -272,7 +272,14 @@
             videoId: {
                 type: String,
                 required: true,
+            },
+            callId: {
+                type: Number,
+                required: true,
             }
-        }
+        },
+        created() {
+            // TODO railsサーバに歌詞をリクエストして、lyricsLinesに格納する
+        },
     }
 </script>

--- a/app/frontend/components/PracticeBody.vue
+++ b/app/frontend/components/PracticeBody.vue
@@ -27,7 +27,7 @@
                 song: "Make you happy",
                 artist: "NiziU",
                 bpm: 160,
-                videoId: "CN11U5t83Ro",
+                // TODO Rails より受け取った歌詞Jsonを格納する
                 lyricsLines: [
                     {
                         "time": 1.694,
@@ -268,5 +268,11 @@
                 ],
             }
         },
+        props: {
+            videoId: {
+                type: String,
+                required: true,
+            }
+        }
     }
 </script>

--- a/app/frontend/components/PreparationBody.vue
+++ b/app/frontend/components/PreparationBody.vue
@@ -56,13 +56,17 @@
                 return this.videoUrl ? false : true
             },
             hasUrlFormatError(){
-                const urlReg = /^(https\:\/\/)?(www\.)?(youtube\.com\/watch\?v=|youtu\.be\/)+[\S]{11}$/
+                const urlReg = /^(https\:\/\/)?(www\.)?(youtube\.com\/watch\?v=|youtu\.be\/)+([\S]{11}$)/
                 if (this.hasNoUrlError) {
                     return false
                 } else {
                     return urlReg.test(this.videoUrl) ? false : true
                 }
             },
+            videoId(){
+                const urlReg = /^(https\:\/\/)?(www\.)?(youtube\.com\/watch\?v=|youtu\.be\/)+([\S]{11}$)/
+                return this.videoUrl.match(urlReg).pop()
+            }
         },
         components: {
             Search,
@@ -76,7 +80,10 @@
                 if (!this.hasNoUrlError && !this.hasUrlFormatError && !this.hasCallError) {
                     setTimeout(() => {
                         this.$router.push({
-                            path: "/practice",
+                            name: "practice",
+                            params: {
+                                videoId: this.videoId
+                            }
                         })
                     }, 90);
                 }

--- a/app/frontend/components/PreparationBody.vue
+++ b/app/frontend/components/PreparationBody.vue
@@ -25,7 +25,7 @@
                         コールを選択してください
                     </v-alert>
                 </div>
-                <Search @checkCallError="setHasCallErrorFlag"></Search>
+                <Search @checkCallError="setHasCallErrorFlag" @sendCallId="setCallId"></Search>
                 <v-row id="start-button" justify="center" align="center">
                     <v-btn color="primary" class="my-4 black--text"
                         depressed x-large rounded width="170px"
@@ -45,6 +45,7 @@
         data() {
             return {
                 videoUrl: "",
+                callId: null,
                 showNoUrlAlert: false,
                 showUrlFormatAlert: false,
                 hasCallError: false,
@@ -82,7 +83,8 @@
                         this.$router.push({
                             name: "practice",
                             params: {
-                                videoId: this.videoId
+                                videoId: this.videoId,
+                                callId: this.callId
                             }
                         })
                     }, 90);
@@ -91,6 +93,9 @@
             setHasCallErrorFlag(hasSelected){
                 this.hasCallError = hasSelected ? false : true;
             },
+            setCallId(callId){
+                this.callId = callId;
+            }
         },
     }
 </script>

--- a/app/frontend/components/Search.vue
+++ b/app/frontend/components/Search.vue
@@ -85,14 +85,16 @@
                         this.results = res.data;
                         this.isLoading = false;
                         this.results.length > 0 ? this.hasResult = true : this.hasResult = false;
-                        this.selectedResult = this.results[0];
+                        this.selectResult(this.results[0]);
                     })
                     .catch(err => {
                         console.error(err.message); 
                     })
                 } else {
                     this.hasResult = false;
+                    this.results = [];
                     this.isValid = false;
+                    this.selectResult(null);
                 }
             },
             hasSelected: {
@@ -104,7 +106,13 @@
         },
         methods: {
             selectResult(result){
-                this.selectedResult = result;
+                if (result) {
+                    this.selectedResult = result;
+                    this.$emit("sendCallId", result.id)
+                } else {
+                    this.selectedResult = null;
+                    this.$emit("sendCallId", null)
+                }
             }
         },
     }

--- a/app/frontend/components/Subtitle.vue
+++ b/app/frontend/components/Subtitle.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="subtitle-area">
+    <div id="subtitle-area" class="mx-16">
         <v-row align="center" justify="center">
             <v-col cols="auto">
                 <v-tooltip top>
@@ -11,7 +11,7 @@
                     <span>字幕ON/OFF</span>
                 </v-tooltip>
             </v-col>
-            <v-col cols="9" class="px-0">
+            <v-col cols="10" class="px-0">
                 <v-sheet v-show="this.isVisible" color="white rounded-pill px-5 py-2" min-height="56px" id="lyrics-wrapper">
                     <Lyrics
                         :lyricsLines="lyricsLines"

--- a/app/frontend/components/Video.vue
+++ b/app/frontend/components/Video.vue
@@ -1,8 +1,27 @@
 <template>
-    <div id="video-area">
-        <v-row justify="center" id="info" class="my-0">
-            <v-icon left color="mainColor" id="music-circle-icon">mdi-music-circle</v-icon>
-            <h4 class="white--text text-center">練習中：{{artist}} - {{song}}</h4>
+    <div id="video-area" class="mx-16">
+        <v-row justify="center" align="center" id="info" class="my-0">
+            <v-col cols="auto" class="py-0">
+                <v-tooltip top>
+                    <template v-slot:activator="{on}">
+                        <v-btn depressed fab color="white" v-on="on" @click="pageBack">
+                            <v-icon x-large color="maccha">mdi-arrow-left</v-icon>
+                        </v-btn>
+                    </template>
+                    <span>戻る</span>
+                </v-tooltip>
+            </v-col>
+            <v-col cols="10">
+                <h3 class="white--text text-center">
+                    <v-icon left color="mainColor" id="music-circle-icon">mdi-music-circle</v-icon>
+                    練習中：{{artist}} - {{song}}
+                </h3>
+            </v-col>
+            <v-col cols="auto" class="py-0">
+                <v-btn disabled fab plain>
+                    <v-icon disabled x-large color="transparent"></v-icon>
+                </v-btn>
+            </v-col>
         </v-row>
         <v-row id="video" justify="center">
             <v-sheet class="ma-0" id="video-player" width="820" color="transparent">
@@ -57,6 +76,9 @@
         },
         methods: {
             ...mapActions(["getVideoCurrentTime"]),
+            pageBack(){
+                this.$router.back();
+            },
             createMouseEvent(x, y){
                 return new MouseEvent("partyEvent", {
                     // 画面の幅の10％〜90％の間にエフェクトが出現する
@@ -119,6 +141,8 @@
         beforeDestroy() {
             clearInterval(this.videoTimeProcessId)
             clearInterval(this.partyLoopProcessId)
+            this.openingAudio.pause()
+            this.openingAudio.currentTime = 0
         },
     }
 </script>

--- a/app/frontend/router/index.js
+++ b/app/frontend/router/index.js
@@ -15,8 +15,10 @@ export default new VueRouter({
             component: PreparationBody,
         },
         {
-            path: "/practice",
+            name: "practice",
+            path: "/practice/:videoId",
             component: PracticeBody,
+            props: true,
         },
     ]
 })

--- a/app/frontend/router/index.js
+++ b/app/frontend/router/index.js
@@ -16,7 +16,7 @@ export default new VueRouter({
         },
         {
             name: "practice",
-            path: "/practice/:videoId",
+            path: "/practice/:videoId/:callId",
             component: PracticeBody,
             props: true,
         },

--- a/babel.config.js
+++ b/babel.config.js
@@ -66,7 +66,9 @@ module.exports = function(api) {
         {
           async: false
         }
-      ]
+      ],
+      ["@babel/plugin-proposal-private-property-in-object", { "loose": true }],
+      ["@babel/plugin-proposal-private-methods", { "loose": true }]
     ].filter(Boolean)
   }
 }


### PR DESCRIPTION
## 変更の概要

* 準備画面から練習画面へのルーティング処理を完成させた
* 関連するIssueやプルリクエスト　#18 

## やったこと

* [x] 入力したYouTUbeリンクからvideoIdを切り取り次のページに渡す処理を記述した
* [x] 選択したコールのcallIdをを次のページに渡す処理を記述した
* [x] 練習画面から準備画面に戻るボタンを設置した
* [x] コンパイル時の警告を表示させないようにした

## 変更内容

* Vueの内部ロジック
* 練習画面のUI（戻るボタン）：
![image](https://user-images.githubusercontent.com/29052488/143153493-3d7dd317-202e-4ecc-a333-d489e2052fe8.png)
