### PR TITLE
Improve: 練習画面、コール表示を改善した

### DIFF
--- a/app/frontend/components/Lyrics.vue
+++ b/app/frontend/components/Lyrics.vue
@@ -81,7 +81,6 @@
 
                     // indexはコール歌詞が元の歌詞において初めて現れたインデックス
                     if (callLyrics) {
-                        console.log("処理されたよ");
                         for(let i=0;i<callLyrics.length;i++){
                             const index = lyric.indexOf(callLyrics[i])
                             indexLyrics[index] = callLyrics[i]

--- a/app/frontend/components/Lyrics.vue
+++ b/app/frontend/components/Lyrics.vue
@@ -5,11 +5,17 @@
         >
             <!-- v-forで回ってきた1行の歌詞を、どのようなHTMLタグで作成するか条件分岐する -->
             <span v-for="(word, index) in splitedLyric(line.lyric)" :key="index">
-                <!-- 歌詞がコール歌詞だと検出したら、特別なstyleとバインドする -->
+                <!-- 歌詞がコール歌詞だと検出したら、背景を着色する -->
                 <span v-if="matchCallLyrics(word)"
                     :style="{backgroundColor:callBackgroundColor}"
                 >
                     {{word}}
+                </span>
+                <!-- 歌詞が合唱コール歌詞だと検出したら、文字を着色する -->
+                <span v-else-if="matchChorusCallLyrics(word)"
+                    :style="{color:darkCallBackgroundColor}"
+                >
+                    {{ word.replace("{", "").replace("}", "") }}
                 </span>
                 <!-- そうでない歌詞はそのまま展示する -->
                 <span v-else>{{word}}</span>
@@ -27,6 +33,7 @@
             return {
                 timeOffset: 0,
                 callBackgroundColor: null,
+                darkCallBackgroundColor: null,
             }
         },
         props: {
@@ -53,23 +60,41 @@
                 }
             },
             splitedLyric(lyric){
-                // コール箇所（中括弧）にマッチする
+                // コール箇所（三角括弧）にマッチする
                 const callReg = /【.*?】/g;
+                // 合唱コール箇所（波括弧）にマッチする
+                const chorusReg = /{.*?}/g;
                 // コール箇所があれば
-                if (callReg.test(lyric)) {
+                if (callReg.test(lyric) || chorusReg.test(lyric)) {
                     // コール箇所以外にマッチするもの
-                    const notCallReg = /[^【】]+(?=【[^【】]+】)|[^【】]+$/g
+                    const notCallReg = /[^【】{}]+(?=[【{][^【】{}]+[】}])|[^【】{}]+$/g
                     
+                    // コール箇所
                     const callLyrics = lyric.match(callReg)
+                    // 合唱コール箇所
+                    const chorusCallLyrics = lyric.match(chorusReg)
+                    // コールではない箇所
                     const notCallLyrics = lyric.match(notCallReg)
 
+                    // 上記3種類の歌詞を整理するための入れ物
                     const indexLyrics = {}
 
-                    // indexはコール歌詞が元の歌詞で初めて現れたインデックス
-                    for(let i=0;i<callLyrics.length;i++){
-                        const index = lyric.indexOf(callLyrics[i])
-                        indexLyrics[index] = callLyrics[i]
+                    // indexはコール歌詞が元の歌詞において初めて現れたインデックス
+                    if (callLyrics) {
+                        console.log("処理されたよ");
+                        for(let i=0;i<callLyrics.length;i++){
+                            const index = lyric.indexOf(callLyrics[i])
+                            indexLyrics[index] = callLyrics[i]
+                        }
                     }
+                    // indexは合唱コール歌詞が元の歌詞において初めて現れたインデックス
+                    if (chorusCallLyrics) {
+                        for(let i=0;i<chorusCallLyrics.length;i++){
+                            const index = lyric.indexOf(chorusCallLyrics[i])
+                            indexLyrics[index] = chorusCallLyrics[i]
+                        }
+                    }
+                    // indexは通常の歌詞が元の歌詞において初めて現れたインデックス
                     if (notCallLyrics) {
                         for(let b=0;b<notCallLyrics.length;b++){
                             const index = lyric.indexOf(notCallLyrics[b])
@@ -84,6 +109,7 @@
     
                     return resultArray
                 } else {
+                    // コール箇所がなければそのまま出す
                     return [lyric]
                 }
             },
@@ -91,11 +117,18 @@
                 const callReg = /【.*?】/g;
                 return callReg.test(word)
             },
+            matchChorusCallLyrics(word){
+                const chorusReg = /{.*?}/g;
+                return chorusReg.test(word)
+            },
         },
         mounted() {
             // 第一引数はsubscribeの名前で、実際は使わないので「_」でポジションをとってくれている。
             Pubsub.subscribe("catchCallBackgroundColor", (_, color)=>{
                 this.callBackgroundColor = color;
+            })
+            Pubsub.subscribe("catchDarkCallBackgroundColor", (_, color)=>{
+                this.darkCallBackgroundColor = color;
             })
         },
         beforeUpdate() {

--- a/app/frontend/components/LyricsFunctions.vue
+++ b/app/frontend/components/LyricsFunctions.vue
@@ -59,7 +59,7 @@
         data() {
             return {
                 isLiked: false,
-                isSpeedDialActive: false,
+                isSpeedDialActive: true,
                 swatches:[
                     "#ff94ce", "#ff9eff", "#c1c1ff", "#99ffff", "#b2ffd8", "#d8ffb2", "#ffffb2", "#ffe0c1"
                 ],

--- a/app/frontend/components/LyricsFunctions.vue
+++ b/app/frontend/components/LyricsFunctions.vue
@@ -1,50 +1,107 @@
 <template>
-    <v-speed-dial direction="top" open-on-click transition="slide-y-reverse-transition" v-model="isSpeedDialActive">
-        <template v-slot:activator>
-            <v-btn depressed fab color="white">
-                <v-icon x-large color="black">mdi-{{optionButton}}</v-icon>
+    <div>
+        <v-speed-dial direction="top" open-on-click transition="slide-y-reverse-transition" v-model="isSpeedDialActive">
+            <template v-slot:activator>
+                <v-btn depressed fab color="white">
+                    <v-icon x-large color="black">mdi-{{optionButton}}</v-icon>
+                </v-btn>
+            </template>
+            <v-btn depressed fab color="white" @click.stop="rewind">
+                <v-tooltip top>
+                    <template v-slot:activator="{on}">
+                        <v-icon x-large color="maccha" v-on="on">mdi-redo</v-icon>
+                    </template>
+                    <span>字幕0.5秒遅らせる</span>
+                </v-tooltip>
             </v-btn>
-        </template>
-        <v-btn depressed fab color="white" @click.stop="rewind">
-            <v-tooltip top>
-                <template v-slot:activator="{on}">
-                    <v-icon x-large color="maccha" v-on="on">mdi-redo</v-icon>
-                </template>
-                <span>字幕0.5秒遅らせる</span>
-            </v-tooltip>
-        </v-btn>
-        <v-btn depressed fab color="white" @click.stop="forward">
-            <v-tooltip top>
-                <template v-slot:activator="{on}">
-                    <v-icon x-large color="maccha" v-on="on">mdi-undo</v-icon>
-                </template>
-                <span>字幕0.5秒早める</span>
-            </v-tooltip>
-        </v-btn>
-        <!-- ユーザー機能を実装していないためお気に入り機能を一旦コメントアウト -->
-        <!-- <v-btn depressed fab color="white" @click.stop="like($event)">
-            <v-tooltip top>
-                <template v-slot:activator="{on}">
-                    <v-icon x-large color="pink" v-on="on">mdi-{{likeButton}}</v-icon>
-                </template>
-                <span>お気に入り</span>
-            </v-tooltip>
-        </v-btn> -->
-        <v-btn depressed fab color="white" @click.stop>
-            <v-tooltip top>
-                <template v-slot:activator="{on}">
-                    <v-sheet v-on="on" color="transparent">
-                        <v-swatches id="color-picker" 
-                            v-model="callBackgroundColor" :swatches="swatches"
-                            popover-x="left" close-on-select shapes="circles"
-                            @input="sendColor"
-                        ></v-swatches>
-                    </v-sheet>
-                </template>
-                <span>コールの背景色</span>
-            </v-tooltip>
-        </v-btn>
-    </v-speed-dial>
+            <v-btn depressed fab color="white" @click.stop="forward">
+                <v-tooltip top>
+                    <template v-slot:activator="{on}">
+                        <v-icon x-large color="maccha" v-on="on">mdi-undo</v-icon>
+                    </template>
+                    <span>字幕0.5秒早める</span>
+                </v-tooltip>
+            </v-btn>
+            <!-- ユーザー機能を実装していないためお気に入り機能を一旦コメントアウト -->
+            <!-- <v-btn depressed fab color="white" @click.stop="like($event)">
+                <v-tooltip top>
+                    <template v-slot:activator="{on}">
+                        <v-icon x-large color="pink" v-on="on">mdi-{{likeButton}}</v-icon>
+                    </template>
+                    <span>お気に入り</span>
+                </v-tooltip>
+            </v-btn> -->
+            <v-btn depressed fab color="white" @click="dialogGuide = true; carousel = 0;">
+                <v-tooltip top>
+                    <template v-slot:activator="{on}">
+                        <v-icon x-large color="maccha" v-on="on">mdi-help-circle</v-icon>
+                    </template>
+                    <span>ヘルプ</span>
+                </v-tooltip>
+            </v-btn>
+            <v-btn depressed fab color="white" @click.stop>
+                <v-tooltip top>
+                    <template v-slot:activator="{on}">
+                        <v-sheet v-on="on" color="transparent">
+                            <v-swatches id="color-picker" 
+                                v-model="callBackgroundColor" :swatches="swatches"
+                                popover-x="left" close-on-select shapes="circles"
+                                @input="sendColor"
+                            ></v-swatches>
+                        </v-sheet>
+                    </template>
+                    <span>コールの背景色</span>
+                </v-tooltip>
+            </v-btn>
+        </v-speed-dial>
+        <v-dialog max-width="800" v-model="dialogGuide">
+            <v-card color="mainColor">
+                <v-card-title>
+                    <h3>Step{{carousel + 1}} / 4</h3>
+                </v-card-title>
+                <v-card-text class="pb-0">
+                    <v-carousel v-model="carousel" class="rounded-t-xl" width="600" height="400"
+                        hide-delimiters :show-arrows="false"
+                    >
+                        <v-carousel-item
+                            v-for="(pic, index) in guidePics" :key="index"
+                        >
+                            <img :src="pic.src" id="guide-pics"/>
+                        </v-carousel-item>
+                    </v-carousel>
+                    <v-list class="rounded-b-xl">
+                        <v-list-item>
+                            <v-list-item-content>
+                                <v-list-item-title>
+                                    {{guideText[carousel]}}
+                                </v-list-item-title>
+                            </v-list-item-content>
+                        </v-list-item>
+                    </v-list>
+                </v-card-text>
+                <v-card-actions>
+                    <v-spacer></v-spacer>
+                    <div class="mb-2">
+                        <v-btn depressed rounded x-large color="white" class="black--text mx-2" 
+                            @click="carousel -= 1" v-show="hasPrev"
+                        >
+                            BACK
+                        </v-btn>
+                        <v-btn depressed rounded x-large color="primary" class="black--text mx-2" 
+                            @click="carousel += 1" v-show="hasNext"
+                        >
+                            NEXT
+                        </v-btn>
+                        <v-btn depressed rounded x-large color="primary" class="black--text mx-2" 
+                            @click="dialogGuide = false" v-show="isLast"
+                        >
+                            OK!
+                        </v-btn>
+                    </div>
+                </v-card-actions>
+            </v-card>
+        </v-dialog>
+    </div>
 </template>
 
 <script>
@@ -75,6 +132,20 @@
                     "#ffe0c1": "#e6934c"
                 },
                 callBackgroundColor: "#ff94ce",
+                dialogGuide: false,
+                carousel: 0,
+                guidePics: [
+                    {src: require('../images/step2.png')},
+                    {src: require('../images/step3.png')},
+                    {src: require('../images/step4.png')},
+                    {src: require('../images/step5.png')}
+                ],
+                guideText: [
+                    "リズムに合わせて、色付きの歌詞でコールしよう！",
+                    "覚えてきたら、字幕をオフにしてみよう",
+                    "歌詞のタイミングが合わない時は調整しよう",
+                    "コールの色を変えてみよう"
+                ],
                 timeOffset: 0,
             }
         },
@@ -87,7 +158,16 @@
             },
             darkCallBackgroundColor(){
                 return this.darkColorList[this.callBackgroundColor]
-            }
+            },
+            hasPrev(){
+                return this.carousel === 0 ? false : true
+            },
+            hasNext(){
+                return this.carousel === 3 ? false : true
+            },
+            isLast(){
+                return this.carousel === 3 ? true : false
+            },
         },
         methods: {
             like(event){
@@ -121,5 +201,8 @@
         left: -1.5px;
         top: 2px;
         background-color: transparent;
+    }
+    #guide-pics{
+        width: 100%;
     }
 </style>

--- a/app/frontend/components/LyricsFunctions.vue
+++ b/app/frontend/components/LyricsFunctions.vue
@@ -63,6 +63,16 @@
                 swatches:[
                     "#ff94ce", "#ff9eff", "#c1c1ff", "#99ffff", "#b2ffd8", "#d8ffb2", "#ffffb2", "#ffe0c1"
                 ],
+                darkColorList: {
+                    "#ff94ce": "#d14f8d", 
+                    "#ff9eff": "#c456d6", 
+                    "#c1c1ff": "#786edc", 
+                    "#99ffff": "#2e9bd1", 
+                    "#b2ffd8": "#42d270", 
+                    "#d8ffb2": "#97cc44", 
+                    "#ffffb2": "#e4ca32", 
+                    "#ffe0c1": "#e6934c"
+                },
                 callBackgroundColor: "#ff94ce",
                 timeOffset: 0,
             }
@@ -74,6 +84,9 @@
             optionButton(){
                 return this.isSpeedDialActive ? "chevron-up" : "dots-vertical"
             },
+            darkCallBackgroundColor(){
+                return this.darkColorList[this.callBackgroundColor]
+            }
         },
         methods: {
             like(event){
@@ -92,10 +105,12 @@
             },
             sendColor(){
                 Pubsub.publish("catchCallBackgroundColor", this.callBackgroundColor)
+                Pubsub.publish("catchDarkCallBackgroundColor", this.darkCallBackgroundColor)
             }
         },
         mounted() {
             Pubsub.publish("catchCallBackgroundColor", this.callBackgroundColor)
+            Pubsub.publish("catchDarkCallBackgroundColor", this.darkCallBackgroundColor)
         },
     }
 </script>

--- a/app/frontend/components/LyricsFunctions.vue
+++ b/app/frontend/components/LyricsFunctions.vue
@@ -21,14 +21,15 @@
                 <span>字幕0.5秒早める</span>
             </v-tooltip>
         </v-btn>
-        <v-btn depressed fab color="white" @click.stop="like($event)">
+        <!-- ユーザー機能を実装していないためお気に入り機能を一旦コメントアウト -->
+        <!-- <v-btn depressed fab color="white" @click.stop="like($event)">
             <v-tooltip top>
                 <template v-slot:activator="{on}">
                     <v-icon x-large color="pink" v-on="on">mdi-{{likeButton}}</v-icon>
                 </template>
                 <span>お気に入り</span>
             </v-tooltip>
-        </v-btn>
+        </v-btn> -->
         <v-btn depressed fab color="white" @click.stop>
             <v-tooltip top>
                 <template v-slot:activator="{on}">

--- a/app/frontend/components/PreparationBody.vue
+++ b/app/frontend/components/PreparationBody.vue
@@ -5,7 +5,7 @@
                 <div class="mb-4">
                     <h1 class="black--text">どのコールを練習しますか？</h1>
                     <p class="gray--text mb-2">
-                        追加済みのコール数：{{callLyricsCount}} 。随時更新します♪
+                        追加済みのコール数：{{callLyricsCount}} 。随時更新中♪
                     </p>
                     <v-alert v-show="showCallAlert" dense rounded color="primary" 
                         icon="mdi-information-outline" class="mb-2">

--- a/app/frontend/components/Search.vue
+++ b/app/frontend/components/Search.vue
@@ -39,6 +39,9 @@
                             <v-list-item-subtitle>
                                 アーティスト：{{result.artist}}
                             </v-list-item-subtitle>
+                            <v-list-item-subtitle>
+                                形式：{{result.language}}
+                            </v-list-item-subtitle>
                             <!-- <v-list-item-subtitle>
                                 コール作成者：{{result.creator}}
                             </v-list-item-subtitle> -->

--- a/app/frontend/components/Video.vue
+++ b/app/frontend/components/Video.vue
@@ -24,7 +24,7 @@
             </v-col>
         </v-row>
         <v-row id="video" justify="center">
-            <v-sheet class="ma-0" id="video-player" width="820" color="transparent">
+            <v-sheet class="ma-0" id="video-player" width="80%" color="transparent">
                 <youtube fitParent ref="youtube" :video-id="videoId" @playing="playing" @paused="paused" @ended="ended"
                     :player-vars="playerVars"
                 ></youtube>

--- a/app/views/calls/search.json.jbuilder
+++ b/app/views/calls/search.json.jbuilder
@@ -1,9 +1,16 @@
+translation_jp = {
+    japanese: "日本語カナ表記",
+    korean: "韓国語",
+    romanized: "ローマ字表記",
+    english: "英語",
+}
+
 json.array! @lyrics_versions do |version|
     json.id(version.id)
     json.title(version.song.title)
     json.bpm(version.song.bpm)
     json.artist(version.song.artist.name)
-    json.language(version.language.name)
+    json.language(translation_jp[version.language.name.intern])
     json.recommend(version.videos.find_by(tag: "recommend")&.url)
     json.guide(version.videos.find_by(tag: "guide")&.url)
     json.creator("Admin")


### PR DESCRIPTION
## 変更の概要

* 変更の概要
練習画面、コール表示を改善した
* 関連するIssueやプルリクエスト
#56  #57 

## なぜこの変更をするのか

* 変更をする理由
1, 機能ボタンの存在感を高めるため。
2, コールの表示を見やすくするため。

## やったこと

* [x] 機能ボタンを最初から開いているようにしました。
* [x] コールを「ファンが叫ぶ」と「一緒に歌う」部分に分け、異なる着色処理に変更した。
* [x] 練習画面にもチュートリアルのダイアログを追加した。

## 変更内容
一旦使わない「お気に入り」ボタンを削除し、代わりにボタンの説明するための「ヘルプ」ボタンを配置しました。
![image](https://user-images.githubusercontent.com/29052488/145237996-5fac443b-d5a8-43c1-ac1f-328033ef8181.png)


## 影響範囲

* ユーザに影響すること：
コールしやすくなった。
* メンバーに影響すること：
コール作成時、波括弧で{}「一緒に歌う」部分を括る必要がある。
中括弧で【】「ファンだけが叫ぶ」部分を括る必要がある。
* システムに影響すること：
2種類のコールを切り分けるため、読み込み処理が若干遅くなる。
