### PR TITLE
Add: Twitterシェア機能と練習後のアンケート画面を作成した。

### DIFF
--- a/app/frontend/components/Rating.vue
+++ b/app/frontend/components/Rating.vue
@@ -1,0 +1,59 @@
+<template>
+    <v-container class="pa-8 black--text">
+        <form action="https://docs.google.com/forms/u/3/d/e/1FAIpQLScR2wgHZGeN0IrysE4m5XEETkxZbxLCOPsiH0gsdtnSD_OzRw/formResponse" method="post" target="dummyIframe" @submit="hasRate = true">
+            <v-col cols="12">
+                <h1 style="font-size:45px;">おつかれさまです！</h1>
+                <v-card outlined class="rounded-xl" color="white">
+                    <v-card-title>
+                        <h3>アプリの使用感はいかがだったでしょうか？</h3>
+                    </v-card-title>
+                    <v-card-subtitle>
+                        よろしければ満足度を教えてください。今後の改善に参考させていただきます。
+                    </v-card-subtitle>
+                    <v-card-text class="text-center">
+                        <v-rating length="5" size="60" background-color="maccha" color="maccha" hover
+                            v-show="!hasRate" v-model="rating" type="radio"
+                        ></v-rating>
+                        <input type="hidden" name="entry.886849203" :value="rating">
+                        <h1 class="maccha--text" v-show="hasRate">
+                            <v-icon color="maccha" large>mdi-handshake</v-icon>
+                            ご協力ありがとうございます！
+                        </h1>
+                    </v-card-text>
+                </v-card>
+            </v-col>
+            <v-col cols="12" class="d-flex justify-space-between">
+                <v-btn x-large depressed class="ma-1 rounded-xl white--text" color="#1DA1F2"
+                    :href="shareTwitter" target="_blank"
+                >
+                    <v-icon color="white">mdi-twitter</v-icon>Twitterにシェア
+                </v-btn>
+                <v-btn x-large depressed class="ma-1 black--text rounded-xl" color="primary" 
+                    type="submit" v-show="!hasRate"
+                >送信</v-btn>
+                <v-btn x-large depressed class="ma-1 white--text rounded-xl" color="pink" 
+                    v-show="hasRate" to="/preparation"
+                >もう一曲練習する</v-btn>
+            </v-col>
+        </form>
+        <iframe name="dummyIframe" style="display:none;"></iframe>
+    </v-container>
+</template>
+
+<script>
+    export default {
+        name: "Rating",
+        data() {
+            return {
+                rating: 0,
+                hasRate: false,
+            }
+        },
+        props: {
+            shareTwitter: {
+                type: String,
+                require: true,
+            }
+        }
+    }
+</script>

--- a/app/frontend/components/Thanks.vue
+++ b/app/frontend/components/Thanks.vue
@@ -45,7 +45,3 @@
         },
     }
 </script>
-
-<style>
-
-</style>

--- a/app/frontend/components/Video.vue
+++ b/app/frontend/components/Video.vue
@@ -18,8 +18,8 @@
                 </h3>
             </v-col>
             <v-col cols="auto" class="py-0">
-                <v-btn disabled fab plain>
-                    <v-icon disabled x-large color="transparent"></v-icon>
+                <v-btn depressed fab color="white" :href="shareTwitter" target="_blank">
+                    <v-icon x-large color="#1DA1F2">mdi-twitter</v-icon>
                 </v-btn>
             </v-col>
         </v-row>
@@ -48,6 +48,11 @@
                 },
                 callBackgroundColor: null,
                 openingAudio: new Audio(require('../audio/OP_5s.mp3')),
+                twitter: {
+                    formDialog: false,
+                    tweet: "https://twitter.com/intent/tweet",
+                    url: "https://sycall.app/",
+                }
             }
         },
         props: {
@@ -73,6 +78,18 @@
             player(){
                 return this.$refs.youtube.player
             },
+            twitterText(){
+                return ` @SycallApp で ${this.artist} のコールを練習しています🎉 `
+            },
+            twitterHashtags(){
+                return `sycall,サイコール,${this.artist},${this.title.replace(/\s+/g, "").toLowerCase()}`
+            },
+            shareTwitter(){
+                return this.twitter.tweet + 
+                        "?text=" + this.twitterText + 
+                        "&url=" + this.twitter.url + 
+                        "&hashtags=" + this.twitterHashtags
+            }
         },
         methods: {
             ...mapActions(["getVideoCurrentTime"]),

--- a/app/frontend/components/Video.vue
+++ b/app/frontend/components/Video.vue
@@ -18,9 +18,14 @@
                 </h3>
             </v-col>
             <v-col cols="auto" class="py-0">
-                <v-btn depressed fab color="white" :href="shareTwitter" target="_blank">
-                    <v-icon x-large color="#1DA1F2">mdi-twitter</v-icon>
-                </v-btn>
+                <v-tooltip top>
+                    <template v-slot:activator="{on}">
+                        <v-btn depressed fab color="white" :href="shareTwitter" target="_blank" v-on="on">
+                            <v-icon x-large color="#1DA1F2">mdi-twitter</v-icon>
+                        </v-btn>
+                    </template>
+                    <span>Twitterにシェア</span>
+                </v-tooltip>
             </v-col>
         </v-row>
         <v-row id="video" justify="center">
@@ -30,15 +35,24 @@
                 ></youtube>
             </v-sheet>
         </v-row>
+        <v-dialog max-width="800" v-model="ratingDialog">
+            <v-card color="mainColor">
+                <Rating :shareTwitter="shareTwitter"></Rating>
+            </v-card>
+        </v-dialog>
     </div>
 </template>
 
 <script>
     import party from "party-js";
     import Pubsub from 'pubsub-js'
+    import Rating from './Rating.vue'
     import {mapActions, mapMutations, mapGetters} from 'vuex'
     export default {
         name: "Video",
+        components: {
+            Rating
+        },
         data() {
             return {
                 playerVars: {
@@ -52,7 +66,8 @@
                     formDialog: false,
                     tweet: "https://twitter.com/intent/tweet",
                     url: "https://sycall.app/",
-                }
+                },
+                ratingDialog: false,
             }
         },
         props: {
@@ -150,6 +165,7 @@
                 for (let i = 0; i < 3; i++) {
                     party.confetti(this.createMouseEvent(windowWidth, windowHeight))
                 }
+                this.ratingDialog = true
             }
         },
         mounted() {


### PR DESCRIPTION
## 変更の概要

* 変更の概要
Twitterシェア機能と練習後のアンケート画面を作成した。
* 関連するIssueやプルリクエスト
#45 

## なぜこの変更をするのか

* 変更をする理由
アプリを拡散していただくため。
サービス改善のため。

## やったこと

* [x] 動画右上にTwitterシェアボタンを設置しました。
* [x] YouTube動画の終了時にアンケート画面を表示させるようにしました。
* [x] サービスの再利用を促すため、「もう一曲練習する」ボタンをアンケート後に表示させました。

## 変更内容
下記のようにシェアボタンと、アンケート画面を作成した。
![image](https://user-images.githubusercontent.com/29052488/145674328-abe288c8-2a0d-4fe0-b301-ecd3c613ed1a.png)

## 影響範囲

* ユーザに影響すること：
気軽にSNSにシェアできるようになる
* メンバーに影響すること：
特になし
* システムに影響すること：
特になし
