### PR TITLE
fix: 複数のタイマーが起動してしまう問題を解消した。

### DIFF
--- a/app/frontend/components/Video.vue
+++ b/app/frontend/components/Video.vue
@@ -129,6 +129,7 @@
                 // ランダムな場所に星の爆けるエフェクト
                 const windowWidth = window.innerWidth;
                 const windowHeight = window.innerHeight;
+                clearInterval(this.partyLoopProcessId);
                 this.partyLoopProcessId = setInterval(() => {
                     party.sparkles(this.createMouseEvent(windowWidth, windowHeight),{
                         color: party.variation.gradientSample(


### PR DESCRIPTION
## 変更の概要

* 変更の概要
練習画面で複数の星エフェクトのタイマーが起動してしまう問題を解消した。
* 関連するIssueやプルリクエスト
#73 

## なぜこの変更をするのか

* 変更をする理由
タイトルのバグを解消するため。

## やったこと

* [x] タイマー実行前にclearIntervalを必ず実行するように変更しました。

## 変更内容
UIの変更はありません。

## 影響範囲

* ユーザに影響すること：
複数タイマーにより動作が重くなるのを解消した。
* メンバーに影響すること：
特になし
* システムに影響すること：
動作が以前より軽くなった

## 動作確認

* 再現手順
1. 練習画面までいく
2. 再生されたら方向キーでYouTubeを早送り、巻き戻しをする
3. 常に1つの星エフェクトが存在することを確認できる
