### PR TITLE
fix: selectedCallInfo が選曲画面で残ってしまう問題を解消した。

### DIFF
--- a/app/frontend/App.vue
+++ b/app/frontend/App.vue
@@ -8,9 +8,7 @@
         </v-snackbar>
         <v-main >
             <transition appear enter-active-class="animate__animated animate__fadeIn">
-                <keep-alive include="PreparationBody">
-                    <router-view></router-view>
-                </keep-alive>
+                <router-view></router-view>
             </transition>
         </v-main>
         <Footer ></Footer>

--- a/app/frontend/components/Search.vue
+++ b/app/frontend/components/Search.vue
@@ -127,6 +127,8 @@
             }
         },
         mounted() {
+            // 選択していたコールがあればクリアしておく
+            this.sendSelectedCallInfo(null);
             axios.get("/calls/get_popular_words")
             .then(res => {
                 this.popularWords = res.data


### PR DESCRIPTION
## 変更の概要

* 変更の概要
selectedCallInfo が選曲画面で残ってしまう問題を解消した。
* 関連するIssueやプルリクエスト
#75 

## なぜこの変更をするのか

* 変更をする理由
selectedCallInfo が選曲画面で残ってしまうと、「選んでいないのに選択している」状態になり良いUXではないと考えたため。

## やったこと

* [x] Preparation コンポーネントの <keep-alive> を削除した
* [x] Search コンポーネントのmounted時にselectedCallInfoをクリアするようにした。

## 変更内容
UIの変更なし

## 影響範囲

* ユーザに影響すること：
選曲画面のデータが残らなくなりますが、より厄介なバグにつながることが軽減されUXが向上する
* メンバーに影響すること：
特になし
* システムに影響すること：
特になし

## 動作確認

* 再現手順
1. 任意のコールを選択します。
2. 練習を始めます。
3. トップページ、または戻るボタンで選曲画面へ戻る。
4. 入力したデータが消えていることを確認できます。
